### PR TITLE
Add DEBUG=2 option for verbose logging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ To enable logging of DNS queries set ```DEBUG=1```:
 docker run -d --restart=always -p 53:53/tcp -p 53:53/udp -e "DEBUG=1" oznu/dns-ad-blocker
 ```
 
+For verbose logging (including source IP) set ```DEBUG=2```.
+
+
 By default this image forwards DNS requests for unknown zones to Google's DNS servers, 8.8.8.8 and 8.8.4.4. You can set your own if required:
 
 ```

--- a/config/dnsmasq.conf
+++ b/config/dnsmasq.conf
@@ -7,6 +7,9 @@
 # Log Queries, disabled by default
 #log-queries
 
+# Logging should be async if enabled, buffer up to 25 lines
+log-async=50
+
 # Set the cache size to something reasonable
 cache-size=2500
 

--- a/config/dnsmasq.conf
+++ b/config/dnsmasq.conf
@@ -4,6 +4,12 @@
 # as the long options legal on the command line. See
 # "/usr/sbin/dnsmasq --help" or "man 8 dnsmasq" for details.
 
+# Never forward plain names (without a dot or domain part)
+domain-needed
+
+# Never forward addresses in the non-routed address spaces
+bogus-priv
+
 # Log Queries, disabled by default
 #log-queries
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,9 +13,11 @@ echo "nameserver $NS2" >> /etc/resolv.conf
 
 # Enable/Disable Debug Mode
 if [[ "$DEBUG" -eq "1" ]]; then
-  sed -i "s/.*log-queries/log-queries/" /etc/dnsmasq.conf
+  sed -i "s/.*log-queries.*/log-queries/" /etc/dnsmasq.conf
+elif [[ "$DEBUG" -eq "2" ]]; then
+  sed -i "s/.*log-queries.*/log-queries=extra/" /etc/dnsmasq.conf
 else
-  sed -i "s/.*log-queries/#log-queries/" /etc/dnsmasq.conf
+  sed -i "s/.*log-queries.*/#log-queries/" /etc/dnsmasq.conf
 fi
 
 # Download the checksum on the remote release


### PR DESCRIPTION
This extends the `DEBUG=1` logging option to support verbose logging in dnsmasq. When `DEBUG=2` is set, verbose logging is enabled.