### PR TITLE
Fixed for sh (rather than bash)

### DIFF
--- a/root/etc/cont-init.d/40-setup
+++ b/root/etc/cont-init.d/40-setup
@@ -40,7 +40,7 @@ echo "-------------------------------------"
 echo
 
 # Add domains to the whitelist
-if [[ ! -z "$WHITELIST" ]]; then
+if [ ! -z "$WHITELIST" ]; then
   > /etc/dnsmasq.whitelist
   [ "$DNSCRYPT" = "1" ] && NS1="127.0.0.1#40" NS2="127.0.0.1#40"
   for job in $(echo "$WHITELIST" | tr "," " "); do


### PR DESCRIPTION
This script fails with the 'sh' shell (on my raspberrypi) due to the user of the bash-only '[[', and thus the whitelisting doesn't work. This fixes it.